### PR TITLE
Safely parse addresses from scripts

### DIFF
--- a/lib/TransactionDb.js
+++ b/lib/TransactionDb.js
@@ -523,12 +523,16 @@ TransactionDb.prototype.getStandardizedTx = function(tx, time, isCoinBase) {
     var val;
     if (txout.s) {
       var s = new Script(txout.s);
-      var addrs = new Address.fromScriptPubKey(s, config.network);
-      // support only for p2pubkey p2pubkeyhash and p2sh
-      if (addrs && addrs.length === 1) {
-        val = {
-          addresses: [addrs[0].toString()]
-        };
+      try {
+        var addrs = new Address.fromScriptPubKey(s, config.network);
+        // support only for p2pubkey p2pubkeyhash and p2sh
+        if (addrs && addrs.length === 1) {
+          val = {
+            addresses: [addrs[0].toString()]
+          };
+        }
+      } catch(e) {
+        val = { addresses: [] }
       }
     }
     return {


### PR DESCRIPTION
Try-Catch block to catch scripts that contain no addresses, such as op_returns