### PR TITLE
Fix for UTXOs not displaying sats correctly in API

### DIFF
--- a/app/models/Address.js
+++ b/app/models/Address.js
@@ -186,7 +186,7 @@ Address.prototype.update = function(next, opts) {
                 vout: x.index,
                 ts: x.ts,
                 scriptPubKey: x.scriptPubKey,
-                amount: x.value_sat / BitcoreUtil.COIN,
+                amount: x.value_sat / (BitcoreUtil.COIN || 100000000),
                 confirmations: x.isConfirmedCached ? (config.safeConfirmations) : x.confirmations,
                 confirmationsFromCache: !!x.isConfirmedCached,
               };

--- a/etc/minersPoolStrings.json
+++ b/etc/minersPoolStrings.json
@@ -203,7 +203,7 @@
       "poolName":"IceMining.ca",
       "url":"https://icemining.ca/",
       "searchStrings":[
-         "IceMining"
+         "iceca"
       ]
    }
 ]

--- a/etc/minersPoolStrings.json
+++ b/etc/minersPoolStrings.json
@@ -14,8 +14,8 @@
       ]
    },
    {
-      "poolName":"yiimp",
-      "url":"http://yiimp.eu/",
+      "poolName":"Unknown yiimp",
+      "url":"https://github.com/tpruvot/yiimp",
       "searchStrings":[
          "yiimp"
       ]
@@ -35,7 +35,7 @@
       ]
    },
    {
-      "poolName":"sapool",
+      "poolName":"Unknown sapool",
       "url":"#",
       "searchStrings":[
          "sapool"
@@ -122,9 +122,9 @@
    },
    {
       "poolName":"The Blocks Factory",
-      "url":"https://dgb-sha.theblocksfactory.com",
+      "url":"https://theblocksfactory.com",
       "searchStrings":[
-         "theblocksfactory.com"
+         "theblocksfactory"
       ]
    },
       {
@@ -132,6 +132,78 @@
       "url":"https://github.com/zone117x/node-stratum-pool/blob/4f298c3ead7651646c27a30601fcdbf6512b367a/lib/transactions.js#L78",
       "searchStrings":[
          "nodeStratum"
+      ]
+   },
+      "poolName":"blazepool",
+      "url":"http://blazepool.com/",
+      "searchStrings":[
+         "blazepool"
+      ]
+   },
+      "poolName":"Brutangs Solo",
+      "url":"http://dgbsolo.brutang.work:5025/static/",
+      "searchStrings":[
+         "Brutangs-Solo-Node"
+      ]
+   },
+      "poolName":"Brutangs Group",
+      "url":"http://dgb.brutang.work:5025/static/",
+      "searchStrings":[
+         "Brutangs-Group-Node"
+      ]
+   },
+      "poolName":"BSOD",
+      "url":"http://bsod.pw/",
+      "searchStrings":[
+         "bsod"
+      ]
+   },
+      "poolName":"Coinminerz",
+      "url":"http://coinminerz.com",
+      "searchStrings":[
+         "Coinminerz"
+      ]
+   },
+      "poolName":"CybtcPool",
+      "url":"https://cybtc.info/",
+      "searchStrings":[
+         "CybtcPool"
+      ]
+   },
+      "poolName":"dgb256.online",
+      "url":"https://dgb256.online/",
+      "searchStrings":[
+         "dgb256.online"
+      ]
+   },
+      "poolName":"HashWiz",
+      "url":"https://hashwiz.io/",
+      "searchStrings":[
+         "hashwiz.io"
+      ]
+   },
+      "poolName":"PersianMine",
+      "url":"https://persianmine.com/pool/en",
+      "searchStrings":[
+         "PersianMine.com"
+      ]
+   },
+      "poolName":"SwineMine",
+      "url":"https://www.swinemine.com/",
+      "searchStrings":[
+         "SwineMine.com"
+      ]
+   },
+      "poolName":"The Crypto Pools",
+      "url":"https://cryptopools.aod-tech.com/",
+      "searchStrings":[
+         "Crypto Pools by AoD Technologies"
+      ]
+   },
+      "poolName":"IceMining.ca",
+      "url":"https://icemining.ca/",
+      "searchStrings":[
+         "IceMining"
       ]
    }
 ]

--- a/etc/minersPoolStrings.json
+++ b/etc/minersPoolStrings.json
@@ -15,7 +15,7 @@
    },
    {
       "poolName":"Unknown yiimp",
-      "url":"https://github.com/tpruvot/yiimp",
+      "url":"https://github.com/tpruvot/yiimp/blob/next/stratum/coinbase.cpp#L100",
       "searchStrings":[
          "yiimp"
       ]
@@ -134,72 +134,84 @@
          "nodeStratum"
       ]
    },
+      {
       "poolName":"blazepool",
       "url":"http://blazepool.com/",
       "searchStrings":[
          "blazepool"
       ]
    },
+      {
       "poolName":"Brutangs Solo",
       "url":"http://dgbsolo.brutang.work:5025/static/",
       "searchStrings":[
          "Brutangs-Solo-Node"
       ]
    },
+      {
       "poolName":"Brutangs Group",
       "url":"http://dgb.brutang.work:5025/static/",
       "searchStrings":[
          "Brutangs-Group-Node"
       ]
    },
+      {
       "poolName":"BSOD",
       "url":"http://bsod.pw/",
       "searchStrings":[
          "bsod"
       ]
    },
+      {
       "poolName":"Coinminerz",
       "url":"http://coinminerz.com",
       "searchStrings":[
          "Coinminerz"
       ]
    },
+      {
       "poolName":"CybtcPool",
       "url":"https://cybtc.info/",
       "searchStrings":[
          "CybtcPool"
       ]
    },
+      {
       "poolName":"dgb256.online",
       "url":"https://dgb256.online/",
       "searchStrings":[
          "dgb256.online"
       ]
    },
+      {
       "poolName":"HashWiz",
       "url":"https://hashwiz.io/",
       "searchStrings":[
          "hashwiz.io"
       ]
    },
+      {
       "poolName":"PersianMine",
       "url":"https://persianmine.com/pool/en",
       "searchStrings":[
          "PersianMine.com"
       ]
    },
+      {
       "poolName":"SwineMine",
       "url":"https://www.swinemine.com/",
       "searchStrings":[
          "SwineMine.com"
       ]
    },
+      {
       "poolName":"The Crypto Pools",
       "url":"https://cryptopools.aod-tech.com/",
       "searchStrings":[
          "Crypto Pools by AoD Technologies"
       ]
    },
+      {
       "poolName":"IceMining.ca",
       "url":"https://icemining.ca/",
       "searchStrings":[

--- a/lib/TransactionDb.js
+++ b/lib/TransactionDb.js
@@ -523,12 +523,16 @@ TransactionDb.prototype.getStandardizedTx = function(tx, time, isCoinBase) {
     var val;
     if (txout.s) {
       var s = new Script(txout.s);
-      var addrs = new Address.fromScriptPubKey(s, config.network);
-      // support only for p2pubkey p2pubkeyhash and p2sh
-      if (addrs && addrs.length === 1) {
-        val = {
-          addresses: [addrs[0].toString()]
-        };
+      try {
+        var addrs = new Address.fromScriptPubKey(s, config.network);
+        // support only for p2pubkey p2pubkeyhash and p2sh
+        if (addrs && addrs.length === 1) {
+          val = {
+            addresses: [addrs[0].toString()]
+          };
+        }
+      } catch(e) {
+        val = { addresses: [] }
       }
     }
     return {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "insight-bitcore-api",
   "description": "An open-source DigiByte blockchain API. The Insight API provides you with a convenient, powerful and simple way to query and broadcast data on the bitcoin network and build your own services with it.",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "author": {
     "name": "DigiByte Team",
     "email": "info@digibyte.io"
@@ -55,7 +55,7 @@
     "start": "node node_modules/grunt-cli/bin/grunt"
   },
   "dependencies": {
-    "async": "*",
+    "async": "0.9.2",
     "base58-native": "0.1.2",
     "bignum": "*",
     "bitauth": "^0.1.1",


### PR DESCRIPTION
Fixes sat value in UTXOs showing NULL

ex:
```
https://digiexplorer.info/api/addr/DRg9hG9FMgMJYoSSVSqVv6BzW8YbGiNeX3/utxo

{"address":"DRg9hG9FMgMJYoSSVSqVv6BzW8YbGiNeX3","txid":"2b34351ffcca32a2dfe887cfab7c8d54b728cc3e29e37ace0382954625656367","vout":2,"ts":1574636960,"scriptPubKey":"76a914e1420b5a41c4723bc89fa52a91dce36044cd5acd88ac","amount":null,"confirmations":6,"confirmationsFromCache":true},{"address":"DRg9hG9FMgMJYoSSVSqVv6BzW8YbGiNeX3","txid":"ec1e5b55718598914e53eb49a11674ab2ad2c76b45e3f173923b63d6c13ff60f","vout":2,"ts":1574636458,"scriptPubKey":"76a914e1420b5a41c4723bc89fa52a91dce36044cd5acd88ac","amount":null,"confirmations":6,"confirmationsFromCache":true},
```
Tested and confirmed on explorer-1.us.digibyteservers.io